### PR TITLE
Bring in changes made in amrex/Tools/RegressionTesting

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -607,6 +607,7 @@ def test_suite(argv):
         #----------------------------------------------------------------------
         # do the comparison
         #----------------------------------------------------------------------
+        output_file = ""
         if not test.selfTest:
 
             if test.outputFile == "":
@@ -632,7 +633,7 @@ def test_suite(argv):
             if not type(params.convert_type(test.nlevels)) is int:
                 test.nlevels = ""
 
-            if args.make_benchmarks is None:
+            if args.make_benchmarks is None and test.doComparison:
 
                 suite.log.log("doing the comparison...")
                 suite.log.indent()
@@ -713,7 +714,7 @@ def test_suite(argv):
 
                     test.compare_successful = test.compare_successful and diff_successful
 
-            else:   # make_benchmarks
+            elif test.doComparison:   # make_benchmarks
 
                 suite.log.log("storing output of {} as the new benchmark...".format(test.name))
                 suite.log.indent()
@@ -758,6 +759,9 @@ def test_suite(argv):
                         else:
                             shutil.copy(test.diffDir, diff_dir_bench)
                     suite.log.log("new diffDir: {}_{}".format(test.name, test.diffDir))
+
+            else:  # don't do a pltfile comparison
+                test.compare_successful = True
 
         else:   # selfTest
 
@@ -891,7 +895,8 @@ def test_suite(argv):
             if os.path.isfile("{}.err.out".format(test.name)):
                 shutil.copy("{}.err.out".format(test.name), suite.full_web_dir)
                 test.has_stderr = True
-            shutil.copy("{}.compare.out".format(test.name), suite.full_web_dir)
+            if test.doComparison:
+                shutil.copy("{}.compare.out".format(test.name), suite.full_web_dir)
             try:
                 shutil.copy("{}.analysis.out".format(test.name), suite.full_web_dir)
             except:
@@ -932,7 +937,8 @@ def test_suite(argv):
             suite.copy_backtrace(test)
 
         else:
-            shutil.copy("{}.status".format(test.name), suite.full_web_dir)
+            if test.doComparison:
+                shutil.copy("{}.status".format(test.name), suite.full_web_dir)
 
 
         #----------------------------------------------------------------------

--- a/suite.py
+++ b/suite.py
@@ -66,6 +66,8 @@ class Test(object):
         self.doVis = 0
         self.visVar = ""
 
+        self.doComparison = True
+
         self.analysisRoutine = ""
         self.analysisMainArgs = ""
         self.analysisOutputImage = ""


### PR DESCRIPTION
This brings in the changes I've made recently to `amrex/Tools/RegressionTesting`, so that the two repositories will be unified. After this is merged, I think we can remove the regression testing stuff from the main amrex repo. 

These changes do two things: 
    * Allow pltfile comparisons to be turned off in favor of running an analysis script on the output instead (useful for SedonaBox which is a MonteCarlo code)
    * If comparisons are done on particles, it now also displays the command used to diff the particle data. 
