### PR TITLE
Display additional information about analysis success / failure on the web page.

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -880,7 +880,7 @@ def test_suite(argv):
                             analysis_successful = False
                             suite.log.warn("analysis failed...")
 
-                        test.compare_successful = test.compare_successful and analysis_successful
+                        test.analysis_successful = analysis_successful
 
             else:
                 if test.doVis or test.analysisRoutine != "":

--- a/test_report.py
+++ b/test_report.py
@@ -347,7 +347,9 @@ def report_single_test(suite, test, tests, failure_msg=None):
         status_file = "{}.status".format(test.name)
         with open(status_file, 'w') as sf:
             if (compile_successful and
-                (test.compileTest or (not test.compileTest and compare_successful))):
+                (test.compileTest or ((not test.compileTest) and 
+                                          compare_successful and 
+                                      test.analysis_successful))):
                 sf.write("PASSED\n")
                 suite.log.success("{} PASSED".format(test.name))
             elif not compile_successful:
@@ -522,7 +524,20 @@ def report_single_test(suite, test, tests, failure_msg=None):
                 ll.item("<h3 class=\"passed\">Successful</h3>")
             else:
                 ll.item("<h3 class=\"failed\">Failed</h3>")
+            ll.outdent()
 
+        if test.analysisRoutine != "":
+            ll.item("Analysis: ")
+            ll.indent()
+
+            if test.analysis_successful:
+                ll.item("<h3 class=\"passed\">Successful</h3>")
+            else:
+                ll.item("<h3 class=\"failed\">Failed</h3>")
+
+            ll.item("<a href=\"{}.analysis.out\">execution output</a>".format(test.name))
+            ll.outdent()
+                            
     ll.write_list()
 
     if (not test.compileTest) and test.doComparison and failure_msg is None:

--- a/test_util.py
+++ b/test_util.py
@@ -356,6 +356,7 @@ def run(string, stdin=False, outfile=None, store_command=False, env=None,
         else:
             if store_command:
                 cf.write(string)
+                cf.write('\n')
             for line in stdout0:
                 cf.write(line)
 


### PR DESCRIPTION
Currently, the analysis routine pass/fail is rolled into the pltfile comparison, making it hard to see why things whether things are really failing sometimes. This PR makes the analysis result be displayed separately on the generated web pages, with its own pass/fail and execution output. 