### PR TITLE
Implemented run_as_script functionality

### DIFF
--- a/example-tests.ini
+++ b/example-tests.ini
@@ -198,9 +198,14 @@ inputFile = inputs-test1-helm
 # inputs file.  Specify that here
 probinFile = probin-test1-helm
 
-# link?File and aux?File (where ? = 1, 2, or 3) give the names of any
-# additional files that are needed to run the executable (e.g. initial
-# models).  These are specified relative to the problem's build
+# a script to run in place of the executable. The script will be copied
+# to the run directory and executed with the given arguments.
+run_as_script = 
+script_args = 
+
+# link?File and aux?File (where ? = any nonnegative integer) give the names
+# of any additional files that are needed to run the executable (e.g.
+# initial models).  These are specified relative to the problem's build
 # directory.  link files are soft-linked to the run directory, aux
 # files are copied to the run directory.
 link1File = helm_table.dat
@@ -278,5 +283,3 @@ diffOpts =
 
 # any runtime parameters to append to the test's commandline
 runtime_params = 
-
-

--- a/params.py
+++ b/params.py
@@ -263,7 +263,9 @@ def load_params(args):
                 invalid = 1
 
         else:
-            if mytest.buildDir == "" or mytest.inputFile == "" or mytest.dim == -1:
+            
+            input_file_invalid = mytest.inputFile == "" and not mytest.run_as_script
+            if mytest.buildDir == "" or input_file_invalid or mytest.dim == -1:
                 warn_msg = ["required params for test {} not set".format(sec),
                             "buildDir = {}".format(mytest.buildDir),
                             "inputFile = {}".format(mytest.inputFile)]

--- a/params.py
+++ b/params.py
@@ -5,6 +5,7 @@ except ImportError:
 import getpass
 import os
 import socket
+import re
 
 import repo
 import suite
@@ -214,8 +215,8 @@ def load_params(args):
         # set the test object data by looking at all the options in
         # the current section of the parameter file
         valid_options = list(mytest.__dict__.keys())
-        valid_options += ["aux1File", "aux2File", "aux3File"]
-        valid_options += ["link1File", "link2File", "link3File"]
+        aux_pat = re.compile("aux\d+File")
+        link_pat = re.compile("link\d+File")
 
         for opt in cp.options(sec):
 
@@ -224,20 +225,23 @@ def load_params(args):
 
             if opt in valid_options or "_" + opt in valid_options:
 
-                if opt in ["aux1File", "aux2File", "aux3File"]:
-                    mytest.auxFiles.append(value)
-
-                elif opt in ["link1File", "link2File", "link3File"]:
-                    mytest.linkFiles.append(value)
-
-                elif opt == "keyword":
+                if opt == "keyword":
                     mytest.keywords = [k.strip() for k in value.split(",")]
 
                 else:
                     # generic setting of the object attribute
                     setattr(mytest, opt, value)
+            
+            elif aux_pat.match(opt):
+                
+                mytest.auxFiles.append(value)
+                
+            elif link_pat.match(opt):
+                
+                mytest.linkFiles.append(value)
 
             else:
+                
                 mysuite.log.warn("unrecognized parameter {} for test {}".format(opt, sec))
 
 

--- a/regtest.py
+++ b/regtest.py
@@ -558,6 +558,9 @@ def test_suite(argv):
         needed_files = []
         if executable is not None:
             needed_files.append((executable, "move"))
+            
+        if test.run_as_script:
+            needed_files.append((test.run_as_script, "copy"))
 
         needed_files.append((test.inputFile, "copy"))
         # strip out any sub-directory from the build dir

--- a/suite.py
+++ b/suite.py
@@ -47,6 +47,9 @@ class Test(object):
         self.linkFiles = []
 
         self.dim = -1
+        
+        self.run_as_script = ""
+        self.script_args = ""
 
         self.restartTest = 0
         self.restartFileNum = -1

--- a/suite.py
+++ b/suite.py
@@ -50,6 +50,7 @@ class Test(object):
         
         self.run_as_script = ""
         self.script_args = ""
+        self.return_code = None
 
         self.restartTest = 0
         self.restartFileNum = -1
@@ -90,6 +91,7 @@ class Test(object):
         self.diffOpts = ""
 
         self.addToCompileString = ""
+        self.ignoreGlobalMakeAdditions = 0
 
         self.runtime_params = ""
 
@@ -140,7 +142,7 @@ class Test(object):
         return [ft for ft in os.listdir(self.output_dir)
                 if os.path.isfile(ft) and ft.startswith("Backtrace.")]
 
-    def get_last_plotfile(self, output_dir=None):
+    def get_compare_file(self, output_dir=None):
         """ Find the last plotfile written.  Note: we give an error if the
             last plotfile is 0.  If output_dir is specified, then we use
             that instead of the default
@@ -148,6 +150,18 @@ class Test(object):
 
         if output_dir is None:
             output_dir = self.output_dir   # not yet implemented
+            
+        if self.run_as_script:
+            
+            outfile = self.outfile
+            filepath = os.path.join(output_dir, outfile)
+            
+            if not os.path.isfile(filepath) or self.crashed:
+                
+                self.log.warn("test did not produce any output")
+                return ""
+                
+            else: return outfile
 
         plts = [d for d in os.listdir(output_dir) if \
                 (os.path.isdir(d) and
@@ -199,6 +213,30 @@ class Test(object):
         compare = not self.doComparison or self.compare_successful
         analysis = self.analysisRoutine == "" or self.analysis_successful
         return compare and analysis
+    
+    @property
+    def crashed(self):
+        """ Whether the test crashed or not """
+        
+        return len(self.backtrace) > 0 or (self.run_as_script and self.return_code != 0)
+    
+    @property
+    def outfile(self):
+        """ The basename of this run's output file """
+        
+        return "{}.run.out".format(self.name)
+        
+    @property
+    def errfile(self):
+        """ The basename of this run's error file """
+        
+        return "{}.err.out".format(self.name)
+        
+    @property
+    def comparison_outfile(self):
+        """ The basename of this run's comparison output file """
+        
+        return "{}.compare.out".format(self.name)
 
     def record_runtime(self, suite):
 
@@ -737,6 +775,8 @@ class Suite(object):
         """ build an executable with the Fortran AMReX build system """
 
         build_opts = ""
+        f_make_additions = self.add_to_f_make_command
+        
         if test is not None:
             build_opts += "NDEBUG={} ".format(f_flag(test.debug, test_not=True))
             build_opts += "ACC={} ".format(f_flag(test.acc))
@@ -748,12 +788,15 @@ class Suite(object):
 
             if not test.addToCompileString == "":
                 build_opts += test.addToCompileString + " "
+                
+            if test.ignoreGlobalMakeAdditions:
+                f_make_additions = ""
 
         all_opts = "{} {} {}".format(self.extra_src_comp_string, build_opts, opts)
 
         comp_string = "{} -j{} AMREX_HOME={} COMP={} {} {} {}".format(
             self.MAKE, self.numMakeJobs, self.amrex_dir,
-            self.FCOMP, self.add_to_f_make_command, all_opts, target)
+            self.FCOMP, f_make_additions, all_opts, target)
 
         self.log.log(comp_string)
         stdout, stderr, rc = test_util.run(comp_string, outfile=outfile)
@@ -768,6 +811,7 @@ class Suite(object):
     def build_c(self, test=None, opts="", outfile=None):
 
         build_opts = ""
+        c_make_additions = self.add_to_c_make_command
 
         if test is not None:
             build_opts += "DEBUG={} ".format(c_flag(test.debug))
@@ -785,12 +829,15 @@ class Suite(object):
 
             if not test.addToCompileString == "":
                 build_opts += test.addToCompileString + " "
+                
+            if test.ignoreGlobalMakeAdditions:
+                c_make_additions = ""
 
         all_opts = "{} {} {}".format(self.extra_src_comp_string, build_opts, opts)
 
         comp_string = "{} -j{} AMREX_HOME={} {} COMP={} {}".format(
             self.MAKE, self.numMakeJobs, self.amrex_dir,
-            all_opts, self.COMP, self.add_to_c_make_command)
+            all_opts, self.COMP, c_make_additions)
 
         self.log.log(comp_string)
         stdout, stderr, rc = test_util.run(comp_string, outfile=outfile)
@@ -806,7 +853,7 @@ class Suite(object):
         if test.useOMP:
             test_env = dict(os.environ, OMP_NUM_THREADS="{}".format(test.numthreads))
 
-        if test.useMPI:
+        if test.useMPI and not test.run_as_script:
             test_run_command = self.MPIcommand
             test_run_command = test_run_command.replace("@host@", self.MPIhost)
             test_run_command = test_run_command.replace("@nprocs@", "{}".format(test.numprocs))
@@ -814,12 +861,17 @@ class Suite(object):
         else:
             test_run_command = base_command
 
+        outfile = test.outfile
+        
+        if test.run_as_script: errfile = None
+        else: errfile = test.errfile
+        
         self.log.log(test_run_command)
         sout, serr, ierr = test_util.run(test_run_command, stdin=True,
-                                         outfile="{}.run.out".format(test.name),
-                                         errfile="{}.err.out".format(test.name),
+                                         outfile=outfile, errfile=errfile,
                                          env=test_env)
         test.run_command = test_run_command
+        test.return_code = ierr
 
     def copy_backtrace(self, test):
         """


### PR DESCRIPTION
This should work with the acoustic_pulse test problem in Castro if run_as_script is set to convergence.sh and convergence.out is specified as outputFile in the configuration file. It also requires ignoreGlobalMakeAdditions = 1 if TEST=TRUE is part of the add_to_c_make_command parameter, and all of the inputs files (and the probin file) to be listed as inputFile, probinFile or an aux/link file.
 