### PR TITLE
Additions to permit disabling web output; small documentation updates

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,7 +92,7 @@ html_compact_lists = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -5,6 +5,25 @@ Configuration Options
 Version Control
 ===============
 
+The toolkit interfaces with Git to provide automated version control operations.
+Repository settings may be configured with the following settings in the .ini file
+supplied to the main script:
+
+  * ``dir``: The absolute path to the repository directory. This is the only
+    required parameter.
+
+  * ``branch``: The git branch to switch to before pulling from the remote or
+    checking out a particular version.
+  
+  * ``hash``: If specified, the toolkit will checkout the version matching the
+    hash instead of pulling from the remote.
+  
+  * ``build``: Should be specified if the repository will serve as a build
+    directory for test problems.
+  
+  * ``comp_string``: A list of any additional environment variables needed
+    by the build system.
+  
 Compilation
 ===========
 

--- a/params.py
+++ b/params.py
@@ -75,7 +75,7 @@ def load_params(args):
                     mysuite.sourceTree = value
 
             elif opt == "testTopDir": mysuite.testTopDir = mysuite.check_test_dir(value)
-            elif opt == "webTopDir": mysuite.webTopDir = os.path.normpath(value) + "/"
+            elif opt == "webTopDir": mysuite.init_web_dir(value)
             elif opt == "reportCoverage": mysuite.reportCoverage = mysuite.reportCoverage or value
             elif opt == "emailTo": mysuite.emailTo = value.split(",")
 

--- a/regtest.py
+++ b/regtest.py
@@ -1182,8 +1182,9 @@ def test_suite(argv):
 
     suite.log.outdent()
 
-    # For temporary run, return now without creating suote report.
+    # For temporary run, return now without creating suite report.
     if args.do_temp_run:
+        suite.delete_tempdirs()
         return num_failed
 
 
@@ -1206,6 +1207,9 @@ def test_suite(argv):
     suite.log.skip()
     suite.log.bold("creating suite report...")
     report.report_all_runs(suite, active_test_list)
+    
+    # delete any temporary directories
+    suite.delete_tempdirs()
 
     def email_developers():
         msg = email.message_from_string(suite.emailBody)


### PR DESCRIPTION
If the webTopDir variable in the configuration file is left blank, all web output will be directed to a temporary directory, and deleted after completion of the test run. Also added some documentation about version control.