### PR TITLE
 Fixed bokeh runtime error during timing plot generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,7 +92,7 @@ html_compact_lists = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -5,6 +5,25 @@ Configuration Options
 Version Control
 ===============
 
+The toolkit interfaces with Git to provide automated version control operations.
+Repository settings may be configured with the following settings in the .ini file
+supplied to the main script:
+
+  * ``dir``: The absolute path to the repository directory. This is the only
+    required parameter.
+
+  * ``branch``: The git branch to switch to before pulling from the remote or
+    checking out a particular version.
+  
+  * ``hash``: If specified, the toolkit will checkout the version matching the
+    hash instead of pulling from the remote.
+  
+  * ``build``: Should be specified if the repository will serve as a build
+    directory for test problems.
+  
+  * ``comp_string``: A list of any additional environment variables needed
+    by the build system.
+  
 Compilation
 ===========
 

--- a/suite.py
+++ b/suite.py
@@ -696,15 +696,22 @@ class Suite(object):
             convf = lambda s: dt.strptime(s, '%Y-%m-%d')
             using_mpl = False
             self.plot_ext = "html"
-            hover_tool = HoverTool(
-                    tooltips=[("index", "$index"), ("date", "@date{%F}"), ("runtime", "@runtime{0.00}")],
-                    formatters={"date": "datetime"})
 
         def convert_date(date):
             """ Convert to a matplotlib readable date"""
 
             if len(date) > 10: date = date[:date.rfind("-")]
             return convf(date)
+            
+        def hover_tool():
+            """
+            Encapsulates hover tool creation to prevent errors when generating
+            multiple documents.
+            """
+            
+            return HoverTool(
+                tooltips=[("date", "@date{%F}"), ("runtime", "@runtime{0.00}")],
+                formatters={"date": "datetime"})
 
         # make the plots
         for t in all_tests:
@@ -749,7 +756,7 @@ class Suite(object):
                 settings = dict(x_axis_type="datetime")
                 if max(times) / min(times) > 10.0: settings["y_axis_type"] = "log"
                 plot = figure(**settings)
-                plot.add_tools(hover_tool)
+                plot.add_tools(hover_tool())
                 
                 plot.circle("date", "runtime", source=source)
                 plot.xaxis.axis_label = "Date"


### PR DESCRIPTION
When making multiple interactive runtime plots with bokeh, the suite would previously crash because of a shared hover tool object between the documents. That should work now - creation of the object is now encapsulated in a function, and a new object is constructed for each document.