### PR TITLE
Removed premature validation of web directory path

### DIFF
--- a/params.py
+++ b/params.py
@@ -186,10 +186,7 @@ def load_params(args):
         mysuite.log.fail("ERROR: required suite-wide directory not specified\n" + \
                          "(sourceTree, amrexDir, sourceDir, testTopDir)")
 
-    # Make sure the web dir is valid (or use the default is none specified)
-    if mysuite.webTopDir == "":
-        mysuite.webTopDir = "{}/{}-web/".format(mysuite.testTopDir, mysuite.suiteName)
-
+    # Make sure the web dir is valid
     if not os.path.isdir(mysuite.webTopDir):
         try: os.mkdir(mysuite.webTopDir)
         except:

--- a/suite.py
+++ b/suite.py
@@ -463,11 +463,6 @@ class Suite(object):
         else:
             
             self.webTopDir = os.path.normpath(dir_name) + '/'
-            
-        if not os.path.isdir(self.webTopDir):
-            
-            self.log.fail("ERROR: Unable to initialize web directory to"
-                    + " {} - invalid path.".format(self.webTopDir))
                     
     def delete_tempdirs(self):
         """


### PR DESCRIPTION
This should fix the bug described in #39. The code block establishing the default web directory path was removed because the suite will now suppress web output instead of using a default when no path is supplied (see #33). Alternatively, we could retain that section, and instead define a separate variable for suppressing web output. It also appears that the code for creating the web directory could be shifted to init_web_dir, replacing the previous check.