### PR TITLE
Builing particle_comparing

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -1011,9 +1011,11 @@ class Suite(object):
         else:
             ctools = []
 
+        self.make_realclean(repo="AMReX")
+
         for t in ctools:
             self.log.log("building {}...".format(t))
-            comp_string, rc = self.build_c(opts="DEBUG=FALSE USE_MPI=FALSE ")
+            comp_string, rc = self.build_c(opts="DEBUG=FALSE USE_MPI=FALSE EBASE=particle_compare ")
             if not rc == 0:
                 self.log.fail("unable to continue, tools not able to be built")
 


### PR DESCRIPTION
Add `make realclean` before building `particle_compare`.

Provide specific target to make so that building `particle_comare` doesn't depend on the default target in `Tools/Postprocessing/C_Src/GNUmakefile` that may change.
