### PR TITLE
[WIP] Avoid recompiling executable if already compiled in previous tests

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -114,6 +114,7 @@ class Test(object):
         self.nlevels = None  # set but running fboxinfo on the output
 
         self.comp_string = None  # set automatically
+        self.executable = None   # set automatically
         self.run_command = None  # set automatically
 
         self.job_info_field1 = ""
@@ -879,8 +880,8 @@ class Suite(object):
 
         test_util.run(cmd)
 
-    def build_c(self, test=None, opts="", target="", outfile=None, c_make_additions=None):
-
+    def get_comp_string_c(self, test=None, opts="", target="",
+                          outfile=None, c_make_additions=None):
         build_opts = ""
         if c_make_additions is None:
             c_make_additions = self.add_to_c_make_command
@@ -911,6 +912,12 @@ class Suite(object):
             self.MAKE, self.numMakeJobs, self.amrex_dir,
             all_opts, self.COMP, c_make_additions, target)
 
+        return comp_string
+
+    def build_c(self, test=None, opts="", target="",
+                outfile=None, c_make_additions=None):
+        comp_string = self.get_comp_string_c( test, opts, target,
+                                              outfile, c_make_additions )
         self.log.log(comp_string)
         stdout, stderr, rc = test_util.run(comp_string, outfile=outfile)
 


### PR DESCRIPTION
By default, when performing several tests with `regression_testing.py`, the executable is recompiled from scratch for every test. The compilation can therefore dominate the time taken by the tests. 

This PR proposes the avoid re-compiling the executable, if it was already compiled with the exact same options in a previous test. We are currently using this feature in order to same time in the Travis CI tests for [WarpX](https://github.com/ECP-WarpX/WarpX).

In practice, this is done by:
- Creating a new `Build` folder, where compiled executable are stored.
- When running a new tests, comparing compiling options to those used in previous tests. If they match, the previous executable is retrieved from the `Build` folder. Note: this assumes that each executable name is unique ; i.e. that
two sets of compiling options cannot produce the same executable name.

In order to obtain the string that contains compiling options, parts of the function `build_c` was extracted as a separate function.