### PR TITLE
[WIP] Avoid recompiling executable if already compiled in previous tests

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -544,7 +544,7 @@ def test_suite(argv):
             # First check whether an executable was already compiled with
             # the same options (not enabled for CMake, for now)
             found_previous_test = False
-            if not suite.useCmake:
+            if test.avoid_recompiling and not suite.useCmake:
                 comp_string = suite.get_comp_string_c(test=test, outfile=coutfile)
                 # Loop over the existing tests
                 for previous_test in test_list:

--- a/suite.py
+++ b/suite.py
@@ -114,6 +114,7 @@ class Test(object):
         self.nlevels = None  # set but running fboxinfo on the output
 
         self.comp_string = None  # set automatically
+        self.executable = None   # set automatically
         self.run_command = None  # set automatically
 
         self.job_info_field1 = ""
@@ -879,8 +880,8 @@ class Suite(object):
 
         test_util.run(cmd)
 
-    def build_c(self, test=None, opts="", target="", outfile=None, c_make_additions=None):
-
+    def get_comp_string_c(self, test=None, opts="", target="",
+                          outfile=None, c_make_additions=None):
         build_opts = ""
         if c_make_additions is None:
             c_make_additions = self.add_to_c_make_command
@@ -911,6 +912,12 @@ class Suite(object):
             self.MAKE, self.numMakeJobs, self.amrex_dir,
             all_opts, self.COMP, c_make_additions, target)
 
+        return comp_string
+
+    def build_c(self, test=None, opts="", target="",
+                outfile=None, c_make_additions=None):
+        comp_string = self.get_comp_string_c( test, opts, target,
+                                              outfile, c_make_additions )
         self.log.log(comp_string)
         stdout, stderr, rc = test_util.run(comp_string, outfile=outfile)
 

--- a/suite.py
+++ b/suite.py
@@ -344,6 +344,7 @@ class Test(object):
 
     # Static member variables, set explicitly in apply_args in Suite class
     compile_only = False
+    avoid_recompiling = False
     skip_comparison = False
     global_tolerance = None
     global_particle_tolerance = None
@@ -1076,6 +1077,7 @@ class Suite(object):
         args = self.args
 
         Test.compile_only = args.compile_only
+        Test.avoid_recompiling = args.avoid_recompiling
         Test.skip_comparison = args.skip_comparison
         Test.global_tolerance = args.tolerance
         Test.global_particle_tolerance = args.particle_tolerance

--- a/test_util.py
+++ b/test_util.py
@@ -343,6 +343,8 @@ def get_args(arg_string=None):
                                           "options that control how the tests are run")
     run_group.add_argument("--compile_only", action="store_true",
                            help="test only that the code compiles, without running anything")
+    run_group.add_argument("--avoid_recompiling", action="store_true",
+                           help="avoid recompiling, if an executable was already build with the same compilation options, in a previous test")
     run_group.add_argument("--with_valgrind", action="store_true",
                            help="run with valgrind")
     run_group.add_argument("--valgrind_options", type=str, default="--leak-check=yes --log-file=vallog.%p",


### PR DESCRIPTION
(This PR re-opens PR #68.)

By default, when performing several tests with regression_testing.py, the executable is recompiled from scratch for every test. The compilation can therefore dominate the time taken by the tests.

This PR proposes the avoid re-compiling the executable, if it was already compiled with the exact same options in a previous test. We are currently using this feature in order to same time in the Travis CI tests for WarpX.

In practice, this is done by:

    Creating a new Build folder, where compiled executable are stored.
    When running a new tests, comparing compiling options to those used in previous tests. If they match, the previous executable is retrieved from the Build folder. Note: this assumes that each executable name is unique ; i.e. that
    two sets of compiling options cannot produce the same executable name.

In order to obtain the string that contains compiling options, parts of the function build_c was extracted as a separate function.