### PR TITLE
Make error message clearer when parameter INI file does not exist

### DIFF
--- a/params.py
+++ b/params.py
@@ -50,6 +50,9 @@ def load_params(args):
 
     log.bold("loading " + args.input_file[0])
 
+    if not os.path.exists(args.input_file[0]):
+        raise OSError("Parameter file {} does not exist".format(args.input_file[0]))
+    
     try: cp.read(args.input_file[0])
     except:
         log.fail("ERROR: unable to read parameter file {}".format(args.input_file[0]))


### PR DESCRIPTION
When the path to the INI file is wrong:

```
Traceback (most recent call last):
  File "./regression_testing/regtest.py", line 1275, in <module>
    n = test_suite(sys.argv[1:])
  File "./regression_testing/regtest.py", line 299, in test_suite
    suite, test_list = params.load_params(args)
  File "/Users/mark/repos/exa/regression_testing/params.py", line 67, in load_params
    for opt in cp.options("main"):
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/configparser.py", line 675, in options
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'main'
```

Is not as clear as `Parameter file <filename> does not exist`