### PR TITLE
Fix Bug when Building AMReX Tools

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -1006,7 +1006,7 @@ class Suite:
 
         for t in ctools:
             self.log.log(f"building {t}...")
-            comp_string, rc = self.build_c(opts="DEBUG=FALSE USE_MPI=FALSE EBASE=particle_compare ")
+            comp_string, rc = self.build_c(opts="DEBUG=FALSE USE_MPI=FALSE EBASE={}".format(t))
             if not rc == 0:
                 self.log.fail("unable to continue, tools not able to be built")
 


### PR DESCRIPTION
`EBASE` controls which tool to compile, so it seems like we should pass each of the values in `ctools` rather than passing always only `particle_compare`. Cross-reference: https://github.com/ECP-WarpX/regression_testing/pull/17. Please feel free to close this if it isn't right.