### PR TITLE
Log Fail: Return Non-Zero Exit Code

### DIFF
--- a/test_util.py
+++ b/test_util.py
@@ -239,7 +239,7 @@ class Log:
             email_developers()
 
         self.close_log()
-        sys.exit()
+        sys.exit(1)
 
     def testfail(self, string):
         """output a test failure to the log"""


### PR DESCRIPTION
Return a non-zero exit code on failed tests/builds/etc.
This avoids that CI returns success in commonly automated settings.

Fix #87