### PR TITLE
Fix: amr.checkpoint_files_output

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -663,7 +663,8 @@ def test_suite(argv):
                     base_cmd += " amr.checkpoint_files_output=1 amr.check_int=%d " % \
                         (test.restartFileNum)
             else:
-                base_cmd += " amr.checkpoint_files_output=0"
+                if suite.check_file_name != "none":
+                    base_cmd += " amr.checkpoint_files_output=0"
 
             base_cmd += f" {suite.globalAddToExecString} {test.runtime_params}"
 


### PR DESCRIPTION
Add only when needed. This otherwise triggers an unused parameter warning, which is an error for checked in WarpX inputs.

Similar to #81