### PR TITLE
Print Output/Run Directory

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -573,6 +573,7 @@ def test_suite(argv):
         #----------------------------------------------------------------------
         # copy the necessary files over to the run directory
         #----------------------------------------------------------------------
+        suite.log.log(f"run & test directory: {output_dir}")
         suite.log.log("copying files to run directory...")
 
         needed_files = []


### PR DESCRIPTION
The run directory is not yet printed in the run routines.
Printing it out helps users to debug failed runs without knowing the intrinsics of the regression test framework.

Similar to #84 / #95