### PR TITLE
Fix Linter: Test.output_dir, JSONDecodeError

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -42,6 +42,7 @@ class Test:
         self.log = None
 
         self.buildDir = ""
+        self.output_dir = ""
 
         self.extra_build_dir = ""
 

--- a/suite.py
+++ b/suite.py
@@ -688,9 +688,9 @@ class Suite:
                 timings = json.load(open(json_file))
                 # Check for proper format
                 item = next(iter(timings.values()))
-                if not isinstance(item, dict): raise JSONDecodeError()
+                if not isinstance(item, dict): raise ValueError
                 return timings
-            except (OSError, JSONDecodeError, StopIteration): pass
+            except (OSError, ValueError, JSONDecodeError, StopIteration): pass
 
         valid_dirs, all_tests = self.get_run_history(check_activity=False)
 


### PR DESCRIPTION
`Test.output_dir`: This member was never properly defined and just gets hooked in with build functions. Define to an empty string to silence and make aware.

`JSONDecodeError`: Cannot raise a JSONDecodeError without providing all its constructor arguments. Raise a ValueError instead.