### PR TITLE
Improve CRASH Message: Scripts

### DIFF
--- a/test_report.py
+++ b/test_report.py
@@ -377,11 +377,14 @@ def report_single_test(suite, test, tests, failure_msg=None):
                 suite.log.testfail(f"{test.name} COMPILE FAILED")
             elif test.crashed:
                 sf.write("CRASHED\n")
-                for btf in test.backtrace:
-                    suite.log.warn(f"+++ Next backtrace: {btf} +++")
-                    suite.log.warn(open(btf, 'r').read())
-                    suite.log.warn(f"+++ End of backtrace: {btf} +++\n")
-                suite.log.testfail(f"{test.name} CRASHED (backtraces produced)")
+                if len(test.backtrace) > 0:
+                    for btf in test.backtrace:
+                        suite.log.warn(f"+++ Next backtrace: {btf} +++")
+                        suite.log.warn(open(btf, 'r').read())
+                        suite.log.warn(f"+++ End of backtrace: {btf} +++\n")
+                    suite.log.testfail(f"{test.name} CRASHED (backtraces produced)")
+                else:
+                    suite.log.testfail(f"{test.name} CRASHED (script failed)")
             else:
                 sf.write("FAILED\n")
                 suite.log.testfail(f"{test.name} FAILED")


### PR DESCRIPTION
Scripts can also cause `test.crashed` to be true, but they often do not contain a backtrace.
A simple reason could be a missing Python import or simply any other non-zero return status in a script.

The message "CRASHED (backtraces produced)" is then misleading, so we change it to "CRASHED (script failed)" if we cannot find backtraces in the test.