### PR TITLE
Fix runAsScript/customRunCmd: No ".ex" After Build

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -546,7 +546,10 @@ def test_suite(argv):
             else:
                 comp_string, rc = suite.build_c(test=test, outfile=coutfile)
 
-            executable = test_util.get_recent_filename(bdir, "", ".ex")
+            if test.run_as_script:
+                executable = None
+            else:
+                executable = test_util.get_recent_filename(bdir, "", ".ex")
 
         test.comp_string = comp_string
 

--- a/regtest.py
+++ b/regtest.py
@@ -546,10 +546,7 @@ def test_suite(argv):
             else:
                 comp_string, rc = suite.build_c(test=test, outfile=coutfile)
 
-            if test.run_as_script:
-                executable = None
-            else:
-                executable = test_util.get_recent_filename(bdir, "", ".ex")
+            executable = test_util.get_recent_filename(bdir, "", ".ex")
 
         test.comp_string = comp_string
 


### PR DESCRIPTION
Build: Do not search for executables if we are running as a script or custom command (e.g., PICMI python script) anyway.