### PR TITLE
Add abs_tolerance

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -232,8 +232,8 @@ def process_comparison_results(stdout, tvars, test):
     indices = filter(lambda i: words[i] in tvars, range(len(words)))
 
     for i in indices:
-        _, _, rel_err = words[i: i + 3]
-        if abs(test.tolerance) <= abs(float(rel_err)):
+        _, abs_err, rel_err = words[i: i + 3]
+        if abs(test.tolerance) < abs(float(rel_err)) and test.abs_tolerance < abs(float(abs_err)):
             return False
 
     return True
@@ -817,16 +817,17 @@ def test_suite(argv):
 
                             command = f"diff {bench_file} {output_file}"
 
-                        elif test.tolerance is not None:
-
-                            command = "{} --abort_if_not_all_found -n 0 -r {} {} {}".format(suite.tools["fcompare"],
-                                                                                            test.tolerance,
-                                                                                            bench_file, output_file)
-
                         else:
 
-                            command = "{} --abort_if_not_all_found -n 0 {} {}".format(suite.tools["fcompare"],
-                                                                                      bench_file, output_file)
+                            command = "{} --abort_if_not_all_found -n 0".format(suite.tools["fcompare"])
+
+                            if test.tolerance is not None:
+                                command += " --rel_tol {}".format(test.tolerance)
+
+                            if test.abs_tolerance is not None:
+                                command += " --abs_tol {}".format(test.abs_tolerance)
+
+                            command += " {} {}".format(bench_file, output_file)
 
                         sout, _, ierr = test_util.run(command,
                                                       outfile=test.comparison_outfile,

--- a/suite.py
+++ b/suite.py
@@ -85,6 +85,7 @@ class Test:
 
         self._doComparison = True
         self._tolerance = None
+        self._abs_tolerance = None
         self._particle_tolerance = None
 
         self.analysisRoutine = ""
@@ -294,6 +295,20 @@ class Test:
 
         self._tolerance = value
 
+    def get_abs_tolerance(self):
+        """ Returns the global absolute tolerance if one was set,
+            and the test-specific one otherwise.
+        """
+
+        if Test.global_abs_tolerance is None:
+            return self._abs_tolerance
+        return Test.global_abs_tolerance
+
+    def set_abs_tolerance(self, value):
+        """ Sets the test-specific absolute tolerance to the specified value. """
+
+        self._abs_tolerance = value
+
     def get_particle_tolerance(self):
         """ Returns the global particle tolerance if one was set,
             and the test-specific one otherwise.
@@ -346,6 +361,7 @@ class Test:
     compile_only = False
     skip_comparison = False
     global_tolerance = None
+    global_abs_tolerance = None
     global_particle_tolerance = None
     performance_params = []
 
@@ -354,6 +370,7 @@ class Test:
     compileTest = property(get_compile_test, set_compile_test)
     doComparison = property(get_do_comparison, set_do_comparison)
     tolerance = property(get_tolerance, set_tolerance)
+    abs_tolerance = property(get_abs_tolerance, set_abs_tolerance)
     particle_tolerance = property(get_particle_tolerance, set_particle_tolerance)
     check_performance = property(get_check_performance, set_check_performance)
     performance_threshold = property(get_performance_threshold, set_performance_threshold)
@@ -979,7 +996,7 @@ class Suite:
         if ("fextract" in self.extra_tools): ftools.append("fextract")
         if ("fextrema" in self.extra_tools): ftools.append("fextrema")
         if ("ftime" in self.extra_tools): ftools.append("ftime")
-        if any([t for t in test_list if t.tolerance is not None]): ftools.append("fvarnames")
+        if any([t for t in test_list if t.tolerance is not None or t.abs_tolerance is not None]): ftools.append("fvarnames")
 
         for t in ftools:
             self.log.log(f"building {t}...")
@@ -1073,6 +1090,7 @@ class Suite:
         Test.compile_only = args.compile_only
         Test.skip_comparison = args.skip_comparison
         Test.global_tolerance = args.tolerance
+        Test.global_abs_tolerance = args.abs_tolerance
         Test.global_particle_tolerance = args.particle_tolerance
         Test.performance_params = args.check_performance
 

--- a/test_util.py
+++ b/test_util.py
@@ -144,7 +144,10 @@ Each test is given its own block, with the general form:
   tolerance = < floating point number representing the largest relative error
                 permitted between the run output and the benchmark for mesh data,
                 default is 0.0 >
-  particle_tolerance = < same as the above, for particle comparisons
+  abs_tolerance = < floating point number representing the largest absolute
+                    error permitted between the run output and the benchmark for
+                    mesh data, default is 0.0 >
+  particle_tolerance = < same as tolerance, for particle comparisons >
   outputFile = < explicit output file to compare with -- exactly as it will
                  be written.  No prefix of the test name will be done >
 
@@ -374,6 +377,8 @@ def get_args(arg_string=None):
                               help="run analysis for each test without comparison to benchmarks")
     comp_options.add_argument("--tolerance", type=float, default=None, metavar="value",
                               help="largest relative error permitted during mesh comparison")
+    comp_options.add_argument("--abs_tolerance", type=float, default=None, metavar="value",
+                              help="largest absolute error permitted during mesh comparison")
     comp_options.add_argument("--particle_tolerance", type=float, default=None, metavar="value",
                               help="largest relative error permitted during particle comparison")
     parser.add_argument("input_file", metavar="input-file", type=str, nargs=1,


### PR DESCRIPTION
The relative error can be very big even though the absolute error is tiny.  For example,
```
 variable name   absolute error  relative error
                   (||A - B||)   (||A - B||/||A||)
level = 0
phi              1.309632362e-32 2.222121514e-16
dphidx           2.234078735e-32 3.648527456e-15
dphidy           3.4666739e-33   1.066195897
```
This PR will allow the users to specify an absolute tolerance.
