### PR TITLE
ftools: Allow to Skip 'em all

### DIFF
--- a/example-tests.ini
+++ b/example-tests.ini
@@ -101,11 +101,19 @@ slack_webhookfile = /home/zingale/.slack.webhook
 slack_channel = "#castro"
 slack_username = "bender"
 
+# We build by default a few tools for output comparison.
+# The build time for those can be skipped if they are not needed.
+#ftools = fcompare fboxinfo fsnapshot
+
 # some regression tests require tools from the AMReX library to extract the 
 # relevant information.
 # Default compiled tools are: fcompare, fboxinfo, fsnapshot
 # should you need additional tools from AMReX, specify the following:
 extra_tools = fextract
+
+# Control the build of the particle_compare tool.
+# Needed for test particle_tolerance option.
+#use_ctools = 1
 
 # Next we specify the source code repositories.  Each git repo is
 # given its own section.  

--- a/params.py
+++ b/params.py
@@ -86,6 +86,8 @@ def load_params(args):
                 mysuite.reportCoverage = mysuite.reportCoverage or value
             elif opt == "emailTo":
                 mysuite.emailTo = value.split(",")
+            elif opt == "ftools":
+                mysuite.ftools = value
             elif opt == "extra_tools":
                 mysuite.extra_tools = value
 

--- a/suite.py
+++ b/suite.py
@@ -424,6 +424,7 @@ class Suite:
 
         self.COMP = "g++"
 
+        self.ftools = ["fcompare", "fboxinfo", "fsnapshot"]
         self.extra_tools = ""
 
         self.add_to_c_make_command = ""
@@ -992,7 +993,7 @@ class Suite:
 
         self.make_realclean(repo="AMReX")
 
-        ftools = ["fcompare", "fboxinfo", "fsnapshot"]
+        ftools = self.ftools
         if ("fextract" in self.extra_tools): ftools.append("fextract")
         if ("fextrema" in self.extra_tools): ftools.append("fextrema")
         if ("ftime" in self.extra_tools): ftools.append("ftime")


### PR DESCRIPTION
Save build time by allowing to skip the build of `ftools`.

In WarpX, we use our own checksums that do dot rely on silver files.
Thus, we can save some CI time by not building the tools.