### PR TITLE
Fix: ftools needs .split()

### DIFF
--- a/params.py
+++ b/params.py
@@ -87,7 +87,7 @@ def load_params(args):
             elif opt == "emailTo":
                 mysuite.emailTo = value.split(",")
             elif opt == "ftools":
-                mysuite.ftools = value
+                mysuite.ftools = value.split()
             elif opt == "extra_tools":
                 mysuite.extra_tools = value
 

--- a/regtest.py
+++ b/regtest.py
@@ -772,7 +772,7 @@ def test_suite(argv):
 
 
             # get the number of levels for reporting
-            if not test.run_as_script:
+            if not test.run_as_script and "fboxinfo" in suite.tools:
 
                 prog = "{} -l {}".format(suite.tools["fboxinfo"], output_file)
                 stdout0, _, rc = test_util.run(prog)


### PR DESCRIPTION
Missing in last PR #110: inputs parsing needs to be split into a list.