### PR TITLE
add 'runtime_params' to -help output

### DIFF
--- a/test_util.py
+++ b/test_util.py
@@ -162,6 +162,9 @@ Each test is given its own block, with the general form:
   runs_to_average = < number of past runs to include when computing the average,
                       default is 5 >
 
+  runtime_params =  < run-time parameters to be added to the test command line 
+                      arguments > 
+
 Getting started:
 
 To set up a test suite, it is probably easiest to write the


### PR DESCRIPTION
I noticed the `runtime_params`  parameter wasn't listed in the `./regtest.py -h` output, so I added an entry. Please feel free to change the wording. 

Thanks!