### PR TITLE
CI: Print error reports when tests fail

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -563,6 +563,10 @@ def test_suite(argv):
         if not test.compile_successful:
             error_msg = "ERROR: compilation failed"
             report.report_single_test(suite, test, test_list, failure_msg=error_msg)
+            # Print compilation error message (useful for CI tests)
+            with open(f"{output_dir}/{test.name}.make.out") as f:
+                print(f.read())
+
             continue
 
         if test.compileTest:
@@ -1078,6 +1082,9 @@ def test_suite(argv):
                         else:
                             analysis_successful = False
                             suite.log.warn("analysis failed...")
+                            # Print analysis error message (useful for CI tests)
+                            with open(outfile) as f:
+                                print(f.read())
 
                         test.analysis_successful = analysis_successful
 

--- a/regtest.py
+++ b/regtest.py
@@ -563,9 +563,11 @@ def test_suite(argv):
         if not test.compile_successful:
             error_msg = "ERROR: compilation failed"
             report.report_single_test(suite, test, test_list, failure_msg=error_msg)
+
             # Print compilation error message (useful for CI tests)
-            with open(f"{output_dir}/{test.name}.make.out") as f:
-                print(f.read())
+            if suite.verbose > 0:
+                with open(f"{output_dir}/{test.name}.make.out") as f:
+                    print(f.read())
 
             continue
 
@@ -1082,9 +1084,11 @@ def test_suite(argv):
                         else:
                             analysis_successful = False
                             suite.log.warn("analysis failed...")
+
                             # Print analysis error message (useful for CI tests)
-                            with open(outfile) as f:
-                                print(f.read())
+                            if suite.verbose > 0:
+                                with open(outfile) as f:
+                                    print(f.read())
 
                         test.analysis_successful = analysis_successful
 

--- a/suite.py
+++ b/suite.py
@@ -967,6 +967,16 @@ class Suite:
         test.run_command = test_run_command
         test.return_code = ierr
 
+        # Print compilation error message (useful for CI tests)
+        if test.return_code != 0 and self.verbose > 0:
+            self.log.warn("Test stdout:")
+            with open(f"{outfile}") as f:
+                print(f.read())
+            if os.path.isfile(errfile):
+                self.log.warn("Test stderr:")
+                with open(f"{errfile}") as f:
+                    print(f.read())
+
     def copy_backtrace(self, test):
         """
         if any backtrace files were output (because the run crashed), find them


### PR DESCRIPTION
Print compilation messages and script output messages when
they fail. This is needed for CI to spot the underlying error.

Port of https://github.com/ECP-WarpX/regression_testing/commit/8abcbe3ac29506034ac7062e30aa1facb68ceeed by @RemiLehe

ping @EZoni 