### PR TITLE
COMP: No Default

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -84,8 +84,8 @@ Using example-tests.ini as a template:
    #. Configure the build settings if necessary. The ``sourceTree`` variable
       determines the build system (C_Src => C++, AMReX =>
       standalone AMReX tests), while ``COMP`` determines the
-      compilers. The ``numMakeJobs`` and ``add_to_c_make_command`` parameters
-      allow for some additional control over the make command.
+      compilers (e.g., ``g++``). The ``numMakeJobs`` and ``add_to_c_make_command``
+      parameters allow for some additional control over the make command.
 
 #. Setting up the repositories:
 

--- a/suite.py
+++ b/suite.py
@@ -424,7 +424,7 @@ class Suite:
         self.MPIcommand = ""
         self.MPIhost = ""
 
-        self.COMP = "g++"
+        self.COMP = ""  # e.g., g++
 
         self.ftools = ["fcompare", "fboxinfo", "fsnapshot"]
         self.extra_tools = ""
@@ -1131,7 +1131,8 @@ class Suite:
         # Define enviroment
         ENV = {}
         ENV =  dict(os.environ) # Copy of current enviroment
-        ENV['CXX'] = self.COMP
+        if self.COMP:
+            ENV['CXX'] = self.COMP
 
         if env is not None: ENV.update(env)
 

--- a/test_util.py
+++ b/test_util.py
@@ -36,7 +36,7 @@ The "main" block specifies the global test suite parameters:
 
   goUpLink = <1: add "Go UP" link at top of the web page >
 
-  COMP  = < name of C/C++ compiler >
+  COMP  = < name of C/C++ compiler, e.g., g++ >
 
   add_to_c_make_command = < any additional defines to add to the make invocation for C_Src AMReX >
 


### PR DESCRIPTION
If we set a default to COMP, we cannot overwrite it with environment variables (i.e., Unix standard: `export CXX=...`).
Since the examples and docs document this well, we can default to no compiler and leave all the config to an environment/package manager.

This reduces surprises when using the regression tests.

cc @lucafedeli88 @PhilMiller