### PR TITLE
verbose > 1: Always Print Output

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -970,7 +970,7 @@ class Suite:
         test.return_code = ierr
 
         # Print compilation error message (useful for CI tests)
-        if test.return_code != 0 and self.verbose > 0:
+        if test.return_code != 0 and self.verbose > 0 or self.verbose > 1:
             self.log.warn("Test stdout:")
             with open(f"{outfile}") as f:
                 print(f.read())


### PR DESCRIPTION
Not sure if we want to merge this, but for some CI runs I need to see the output file if analysis failed.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/4393