### PR TITLE
Support running regtests.py outside .ini directory

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -402,7 +402,7 @@ class Suite:
         # and build directories
         self.repos = {}
 
-        self.test_file_path = os.getcwd() + '/' + self.args.input_file[0]
+        self.test_file_path = os.path.abspath(self.args.input_file[0])
 
         self.suiteName = "testDefault"
         self.sub_title = ""


### PR DESCRIPTION
Now it is possible to give an absolute or relative path to the .ini
file, rather than needing to invoke regtests.py from the directory in
which the .ini file is located.
