### PR TITLE
Case insensitivity for link?File and aux?File

### DIFF
--- a/params.py
+++ b/params.py
@@ -236,8 +236,8 @@ def load_params(args):
         # set the test object data by looking at all the options in
         # the current section of the parameter file
         valid_options = list(mytest.__dict__.keys())
-        aux_pat = re.compile(r"aux\d+File")
-        link_pat = re.compile(r"link\d+File")
+        aux_pat = re.compile(r"aux\d+File", re.IGNORECASE)
+        link_pat = re.compile(r"link\d+File", re.IGNORECASE)
 
         for opt in cp.options(sec):
 


### PR DESCRIPTION
When specifying a softlinked / copied file, `link?File` / `aux?File` are now case insensitive. This is consistent with [ConfigParser's default behavior](https://docs.python.org/3/library/configparser.html#id1), which is that "keys in sections are case-insensitive."