### PR TITLE
Fix report_single_test for cases with NaNs

### DIFF
--- a/test_report.py
+++ b/test_report.py
@@ -650,7 +650,7 @@ def report_single_test(suite, test, tests, failure_msg=None):
                         line.strip().replace('<', '&lt;').replace('>', '&gt;'))
                     continue
 
-                fields = [q.strip() for q in line.split("  ") if not q == ""]
+                fields = [q.strip() for q in line.split("  ") if not q.strip() == ""]
 
                 if fields:
                     if fields[0].startswith("variable"):


### PR DESCRIPTION
The function was broken by https://github.com/AMReX-Codes/amrex/pull/3823. When a variable contains NaNs, the line used to be `< NaN present >\n`, but now it's `< NaN present >` followed by white spaces and then `\n`. In that case, the line is now split into three fields instead of two, and we should skip the last field with just white spaces.
