### PR TITLE
make the option to fail if no output optional

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -1209,7 +1209,7 @@ def test_suite(argv):
                         except OSError:
                             suite.log.warn(f"unable to remove {pfile}")
 
-        if (match_count == 0):
+        if suite.fail_on_no_output and match_count == 0:
             suite.log.fail("ERROR: test output could not be found!")
 
 

--- a/suite.py
+++ b/suite.py
@@ -494,6 +494,9 @@ class Suite:
         # For setting a specific version of cmake
         self.cmake = "cmake"
 
+        # do we fail if there is no output?
+        self.fail_on_no_output = 0
+
     @property
     def timing_default(self):
         """ Determines the format of the wallclock history JSON file """


### PR DESCRIPTION
different codes have different ways of doing output, so this should be generalized in the future if we want it always on