### PR TITLE
convert images with PIL

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -789,8 +789,6 @@ def test_suite(argv):
             if not test.doComparison:
                 test.compare_succesful = not test.crashed
 
-            print(f"at the top of the make_benchamrks: {test.doComparison=}, {args.make_benchmarks=}")
-
             if args.make_benchmarks is None and test.doComparison:
 
                 suite.log.log("doing the comparison...")
@@ -910,8 +908,6 @@ def test_suite(argv):
                     test.compare_successful = test.compare_successful and diff_successful
 
             elif test.doComparison:   # make_benchmarks
-
-                print("!!!!!! here -- we should be making benchmarks")
 
                 if not compare_file == "":
 

--- a/regtest.py
+++ b/regtest.py
@@ -1058,7 +1058,9 @@ def test_suite(argv):
                             ppm_file = test_util.get_recent_filename(output_dir, "", ".ppm")
                             if not ppm_file is None:
                                 png_file = ppm_file.replace(".ppm", ".png")
-                                test_util.run(f"convert {ppm_file} {png_file}")
+                                from PIL import Image
+                                with Image.open(ppm_file) as im:
+                                    im.save(png_file)
                                 test.png_file = png_file
 
                     # analysis

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib>=2.1.0
 sphinx_rtd_theme
 Sphinx
 nbsphinx>=0.3.1
+pillow


### PR DESCRIPTION
Use `pillow` to convert images from PPM to PNG instead of Imagemagick. This makes all dependencies installable with `pip`.