### PR TITLE
Fix typo in `compare_successful` variable assignment

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -787,7 +787,7 @@ def test_suite(argv):
                     test.nlevels = ""
 
             if not test.doComparison:
-                test.compare_succesful = not test.crashed
+                test.compare_successful = not test.crashed
 
             if args.make_benchmarks is None and test.doComparison:
 


### PR DESCRIPTION
While working on #146, I found that there is a typo in one assignment of the `Test` class attribute `compare_successful`.