### PR TITLE
update submodules when doing git fetch

### DIFF
--- a/params.py
+++ b/params.py
@@ -163,6 +163,10 @@ def load_params(args):
     if args.source_pr is not None:
         mysuite.repos["source"].pr_wanted = args.source_pr
 
+    # update Git submodules?
+    if args.updateGitSubmodules is not None:
+        mysuite.updateGitSubmodules = args.updateGitSubmodules
+    
     # now flesh out the compile strings -- they may refer to either themselves
     # or the source dir
     for r in mysuite.repos.keys():

--- a/params.py
+++ b/params.py
@@ -163,10 +163,6 @@ def load_params(args):
     if args.source_pr is not None:
         mysuite.repos["source"].pr_wanted = args.source_pr
 
-    # update Git submodules?
-    if args.updateGitSubmodules is not None:
-        mysuite.updateGitSubmodules = args.updateGitSubmodules
-    
     # now flesh out the compile strings -- they may refer to either themselves
     # or the source dir
     for r in mysuite.repos.keys():

--- a/repo.py
+++ b/repo.py
@@ -98,12 +98,13 @@ class Repo:
 
             shutil.copy(f"git.{self.name}.out", self.suite.full_web_dir)
 
-        # update submodules to those specified by the current commit
-        # (--init is required because there may be new submodules since the last checkout)
-        _, _, rc = test_util.run(f"git submodule update --init")
+        if self.suite.updateGitSubmodules == 1:
+            # update submodules to those specified by the current commit
+            # (--init is required because there may be new submodules since the last checkout)
+            _, _, rc = test_util.run(f"git submodule update --init")
 
-        if rc != 0:
-            self.suite.log.fail("ERROR: git submodule update was unsuccessful")
+            if rc != 0:
+                self.suite.log.fail("ERROR: git submodule update was unsuccessful")
         
     def save_head(self):
         """Save the current head of the repo"""

--- a/repo.py
+++ b/repo.py
@@ -101,6 +101,7 @@ class Repo:
         if self.suite.updateGitSubmodules == 1:
             # update submodules to those specified by the current commit
             # (--init is required because there may be new submodules since the last checkout)
+            self.suite.log.log(f"git submodule update in {self.dir}")
             _, _, rc = test_util.run(f"git submodule update --init")
 
             if rc != 0:

--- a/repo.py
+++ b/repo.py
@@ -98,6 +98,13 @@ class Repo:
 
             shutil.copy(f"git.{self.name}.out", self.suite.full_web_dir)
 
+        # update submodules to those specified by the current commit
+        # (--init is required because there may be new submodules since the last checkout)
+        _, _, rc = test_util.run(f"git submodule update --init")
+
+        if rc != 0:
+            self.suite.log.fail("ERROR: git submodule update was unsuccessful")
+        
     def save_head(self):
         """Save the current head of the repo"""
 

--- a/suite.py
+++ b/suite.py
@@ -419,7 +419,7 @@ class Suite:
         self.useCmake = 0
         self.isSuperbuild = 0
         self.use_ctools = 1
-
+        
         self.reportCoverage = args.with_coverage
 
         # set automatically
@@ -435,6 +435,8 @@ class Suite:
         self.amrex_install_dir = "" # Cmake installation dir
         self.amrex_cmake_opts = ""
 
+        self.updateGitSubmodules = 0
+        
         self.MPIcommand = ""
         self.MPIhost = ""
 

--- a/test_util.py
+++ b/test_util.py
@@ -28,6 +28,9 @@ The "main" block specifies the global test suite parameters:
   isSuperbuild   = < 0: pre-build AMReX and source (default)
                      1: CMake downloads AMReX and needs separate configure & build >
 
+  updateGitSubmodules = < 0: don't update submodules when changing git branches (default)
+                       1: run `git submodule update --init` after changing git branches >
+
   sourceTree = < C_Src or AMReX >
 
   suiteName = < descriptive name (i.e. Castro) >


### PR DESCRIPTION
This updates submodules with `git submodule update --init` after updating the git commit.

`--init` is required because there may be new submodules since the last checkout.

We need this for the Quokka GPU regression tests to work properly.