### PR TITLE
add bokeh to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 Sphinx
 nbsphinx>=0.3.1
 pillow
+bokeh


### PR DESCRIPTION
Adds `bokeh` to `requirements.txt`. Fully-featured timing plots require Bokeh for plotting: https://bokeh.org/

The matplotlib plots that it falls back on when bokeh is not importable lack dates, e.g.:
https://quokka-astro.github.io/regression-testing-results/Sedov-GPU-timings.png