### PR TITLE
add option to delete executable if test passes

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -1235,6 +1235,10 @@ def test_suite(argv):
                         shutil.rmtree(file_path)
                 # switch to the full test directory
                 os.chdir(suite.full_test_dir)
+            if args.delete_exe:
+                suite.log.log("removing executable from test directory...")
+                os.remove(executable)
+
 
     #--------------------------------------------------------------------------
     # Clean Cmake build and install directories if needed

--- a/test_util.py
+++ b/test_util.py
@@ -392,6 +392,8 @@ def get_args(arg_string=None):
                                help="log file to write output to (in addition to stdout")
     suite_options.add_argument("--clean_testdir", action="store_true",
                                help="remove individual test directory after each passed test")
+    suite_options.add_argument("--delete_exe", action="store_true",
+                               help="remove executable in test directory after each passed test")
 
     comp_options = parser.add_argument_group("comparison options",
                                              "options that control how the comparisons are done")


### PR DESCRIPTION
This adds the `--delete_exe` option to the command line. It deletes the binary in the test directory after the test passes.

This is needed for our CI machine to avoid disk quota issues.