### PR TITLE
Do incremental build on multiple tests

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -490,6 +490,12 @@ def test_suite(argv):
     runtimes = suite.get_wallclock_history()
 
     #--------------------------------------------------------------------------
+    # Track if we're running multiple tests for incremental build optimization
+    #--------------------------------------------------------------------------
+    running_multiple_tests = len(test_list) > 1
+    first_cmake_build_done = False
+
+    #--------------------------------------------------------------------------
     # main loop over tests
     #--------------------------------------------------------------------------
     for test in test_list:
@@ -523,15 +529,20 @@ def test_suite(argv):
         os.chdir(bdir)
 
         if test.reClean == 1:
-            # for one reason or another, multiple tests use different
-            # build options, make clean again to be safe
-            suite.log.log("re-making clean...")
-            if not test.extra_build_dir == "":
-                suite.make_realclean(repo=test.extra_build_dir)
-            elif suite.sourceTree in ["AMReX", "amrex"]:
-                suite.make_realclean(repo="AMReX")
+            # Skip clean for subsequent tests when running multiple tests with cmake
+            # to enable incremental builds
+            if suite.useCmake and running_multiple_tests and first_cmake_build_done:
+                suite.log.log("skipping clean for incremental cmake build...")
             else:
-                suite.make_realclean()
+                # for one reason or another, multiple tests use different
+                # build options, make clean again to be safe
+                suite.log.log("re-making clean...")
+                if not test.extra_build_dir == "":
+                    suite.make_realclean(repo=test.extra_build_dir)
+                elif suite.sourceTree in ["AMReX", "amrex"]:
+                    suite.make_realclean(repo="AMReX")
+                else:
+                    suite.make_realclean()
 
         # Register start time
         test.build_time = time.time()
@@ -542,7 +553,9 @@ def test_suite(argv):
 
         if suite.sourceTree == "C_Src" or test.testSrcTree == "C_Src":
             if suite.useCmake:
-                comp_string, rc = suite.build_test_cmake(test=test, outfile=coutfile)
+                # Skip cmake configuration for subsequent tests when running multiple tests
+                skip_config = running_multiple_tests and first_cmake_build_done
+                comp_string, rc = suite.build_test_cmake(test=test, outfile=coutfile, skip_config=skip_config)
             else:
                 comp_string, rc = suite.build_c(test=test, outfile=coutfile)
 
@@ -553,6 +566,9 @@ def test_suite(argv):
         # make return code is 0 if build was successful
         if rc == 0:
             test.compile_successful = True
+            # Mark that we've successfully completed the first cmake build
+            if suite.useCmake and not first_cmake_build_done:
+                first_cmake_build_done = True
         # Compute compile time
         test.build_time = time.time() - test.build_time
         suite.log.log(f"Compilation time: {test.build_time:.3f} s")

--- a/suite.py
+++ b/suite.py
@@ -1173,7 +1173,12 @@ class Suite:
             os.mkdir(installdir)
 
         # Logfile
-        coutfile = f'{self.full_test_dir}{name}.cmake.log'
+        # Use generic 'cmake.log' for test configurations (since we only configure once)
+        # Keep specific names for AMReX and suite configurations
+        if test is not None:
+            coutfile = f'{self.full_test_dir}cmake.log'
+        else:
+            coutfile = f'{self.full_test_dir}{name}.cmake.log'
 
         # Run cmake
         cmd = f'{self.cmake} {configOpts} -S {path} -B {builddir} '

--- a/suite.py
+++ b/suite.py
@@ -1262,7 +1262,7 @@ class Suite:
 
 
 
-    def build_test_cmake(self, test, opts="",  outfile=None):
+    def build_test_cmake(self, test, opts="",  outfile=None, skip_config=False):
         """ build an executable with CMake build system """
 
         env = {"AMReX_ROOT":self.amrex_install_dir}
@@ -1270,7 +1270,8 @@ class Suite:
         # super-builds always need a configure now, all other builds might
         # add additional CMake config options and re-configure on existing configured
         # build directory, if additional build cmakeSetupOpts are set
-        if self.isSuperbuild or test.cmakeSetupOpts != "":
+        # skip_config can be used to skip reconfiguration for incremental builds
+        if not skip_config and (self.isSuperbuild or test.cmakeSetupOpts != ""):
             builddir, installdir = self.cmake_config(
                 name=test.name,
                 path=self.source_dir,


### PR DESCRIPTION
When doing benchmark on multiple tests, it makes sense to do incremental build instead of re-config before every build. This PR changes the code to do incremental build by default. 